### PR TITLE
Fix Flutter plugin in Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        // ✅ This is needed to fetch the Flutter Gradle plugin
+        maven {
+            url 'https://storage.googleapis.com/download.flutter.io'
+        }
+    }
+}
+
 plugins {
+    id "dev.flutter.flutter-gradle-plugin" version "1.0.0"
     id 'com.android.application' version '8.2.2' apply false
     id 'com.android.library' version '8.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
     id 'com.google.gms.google-services' version '4.4.1' apply false
-    id 'dev.flutter.flutter-gradle-plugin' version '1.0.0' apply false
 }
 
 ext.kotlin_version = '1.9.22'


### PR DESCRIPTION
## Summary
- add `pluginManagement` block and configure `dev.flutter.flutter-gradle-plugin`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688cfa32ccd4832b82f20bac267e6c85