### PR TITLE
Fix Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,3 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-        // ✅ This is needed to fetch the Flutter Gradle plugin
-        maven {
-            url 'https://storage.googleapis.com/download.flutter.io'
-        }
-    }
-}
-
 plugins {
     id "dev.flutter.flutter-gradle-plugin" version "1.0.0"
     id 'com.android.application' version '8.2.2' apply false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,6 +3,8 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        // Repository for the Flutter Gradle plugin
+        maven { url 'https://storage.googleapis.com/download.flutter.io' }
     }
 }
 


### PR DESCRIPTION
## Summary
- remove invalid `pluginManagement` block from `android/build.gradle`
- add Flutter plugin repository to `android/settings.gradle`

## Testing
- `flutter test` *(fails: command not found)*
- `bash ./gradlew -p android tasks --group build` *(fails: unable to download gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_688cff331634832bb8ba70057c05c00f